### PR TITLE
Removed conditional callback calling

### DIFF
--- a/lib/src/otpless_web.dart
+++ b/lib/src/otpless_web.dart
@@ -98,8 +98,7 @@ class Otpless {
 
     js.context['getResponse'] = (String? message) {
       if (functionName == 'verifyAuth') {
-        if (message != null &&
-            jsonDecode(message)["responseType"] == "ONETAP") {
+        if (message != null) {
           onHeadlessResult(message);
         }
       } else {


### PR DESCRIPTION
When user enters the wrong OTP in that case responseType is VERIFY and previously callback is getting called only when responseType is ONETAP, leading to ignoring error case. callback will get called on any responseType. User can manage conditions as per their choice